### PR TITLE
4.8.5 -- Hotfix and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,41 @@ Clicking this button will reveal a menu with each of the avatar decorations in a
 ![avatar decorations](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/54597f3e-b115-44dd-9804-3aee5d9c99b3)
 
 Clicking one of these avatar decorations will copy the invisible 3y3-encoded data into your clipboard.
-<br>Now simply paste your clipboard into the "About Me" section of your profile and save your changes!
+<br>Now follow one of the following methods to apply the avatar decoration to your profile:
 
-![decoration demonstration](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/b91fcd6e-389f-4adf-aa92-054d3e18d524)
+<details>
+ <summary>
+ Custom Status 
+</summary>
+ Now that you have the 3y3 encoded data in your clipboard, close settings by pressing Escape or hitting the button labeled ESC in the top right.
 
-Now you should see the avatar decoration appear around your profile picture!
+ Click on your profile in the bottom left to open this menu:
+ 
+ ![profile](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/2e48a60a-b235-48fd-a93f-b14c6a2ba695)
+
+ Click the button to add/edit your custom status and paste your clipboard into your status.
+
+ You should now see the avatar decoration appear around your profile picture!
+</details>
+
+<details>
+ <summary>
+ About Me / Profile Bio
+</summary>
+ Now that you have the 3y3 encoded data in your clipboard, paste your clipboard into the About Me section of your profile.
+
+ Demonstration:
+ 
+ ![decoration demonstration](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/b91fcd6e-389f-4adf-aa92-054d3e18d524)
+ 
+</details>
+
+
+
+
 
 But of course, this wouldn't be very useful if only _you_ could see it!
-<br>So, of course, I've made it so that any other user of YABDP4Nitro with Fake Avatar Decorations enabled will also be able to see your avatar decoration after they have opened your profile.
+<br>So, of course, I've made it so that any other user of YABDP4Nitro with Fake Avatar Decorations enabled will also be able to see your avatar decoration.
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,15 @@ Clicking this button will reveal a menu with each of the avatar decorations in a
 ![avatar decorations](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/54597f3e-b115-44dd-9804-3aee5d9c99b3)
 
 Clicking one of these avatar decorations will copy the invisible 3y3-encoded data into your clipboard.
-<br>Now follow one of the following methods to apply the avatar decoration to your profile:
+<br>Now follow one or both of the following methods to apply the avatar decoration to your profile:
 
 <details>
  <summary>
  Custom Status 
 </summary>
- Now that you have the 3y3 encoded data in your clipboard, close settings by pressing Escape or hitting the button labeled ESC in the top right.
+ Now that you have the 3y3 encoded data in your clipboard:
+ 
+ Close settings by pressing Escape or hitting the button labeled ESC in the top right.
 
  Click on your profile in the bottom left to open this menu:
  
@@ -146,20 +148,21 @@ Clicking one of these avatar decorations will copy the invisible 3y3-encoded dat
  <summary>
  About Me / Profile Bio
 </summary>
- Now that you have the 3y3 encoded data in your clipboard, paste your clipboard into the About Me section of your profile.
+ Now that you have the 3y3 encoded data in your clipboard:
+ <br>Paste your clipboard into the About Me section of your profile.
 
  Demonstration:
  
  ![decoration demonstration](https://github.com/riolubruh/YABDP4Nitro/assets/54255074/b91fcd6e-389f-4adf-aa92-054d3e18d524)
+
+ **Note: If your Avatar Decoration is in the About Me section of your profile, it will only appear for other users *after* they have opened your profile at least once.**
  
 </details>
 
+<br>
+Any other user of YABDP4Nitro with Fake Avatar Decorations enabled will now be able to see your avatar decoration.
 
-
-
-
-But of course, this wouldn't be very useful if only _you_ could see it!
-<br>So, of course, I've made it so that any other user of YABDP4Nitro with Fake Avatar Decorations enabled will also be able to see your avatar decoration.
+___
 
 ## Miscellaneous
 

--- a/YABDP4Nitro.plugin.js
+++ b/YABDP4Nitro.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name YABDP4Nitro
  * @author Riolubruh
- * @version 4.8.4
+ * @version 4.8.5
  * @source https://github.com/riolubruh/YABDP4Nitro
  * @updateUrl https://raw.githubusercontent.com/riolubruh/YABDP4Nitro/main/YABDP4Nitro.plugin.js
  */
@@ -38,7 +38,7 @@ module.exports = (() => {
 				"discord_id": "359063827091816448",
 				"github_username": "riolubruh"
 			}],
-			"version": "4.8.4",
+			"version": "4.8.5",
 			"description": "Unlock all screensharing modes, and use cross-server & GIF emotes!",
 			"github": "https://github.com/riolubruh/YABDP4Nitro",
 			"github_raw": "https://raw.githubusercontent.com/riolubruh/YABDP4Nitro/main/YABDP4Nitro.plugin.js"
@@ -405,21 +405,27 @@ module.exports = (() => {
 							}
 						}
 						
-						let revealedText = ""
-						if(downloadedUserProfiles.includes(args[0])){
-							let userProfile = userProfileMod.getUserProfile(args[0]);
-							revealedText = secondsightify(String(userProfile.bio));
-						}
-						if(DiscordModules.UserStatusStore.getActivities(args[0]).length > 0){
-							let activities = DiscordModules.UserStatusStore.getActivities(args[0]);
-							if(activities[0].name != "Custom Status") return;
-							let customStatus = activities[0].state;
-							if(customStatus == undefined) return;
-							if(revealedText != undefined){
-								if(revealedText.includes("/a")) return; //already got revealedText from bio
+						function getRevealedText(){
+							let revealedTextLocal = "";
+							if(downloadedUserProfiles.includes(args[0])){
+								let userProfile = userProfileMod.getUserProfile(args[0]);
+								revealedTextLocal = secondsightify(String(userProfile.bio));
+								if(revealedTextLocal != undefined){
+									if(String(revealedTextLocal).includes("/a")){
+										return revealedTextLocal;
+									}
+								}
 							}
-							revealedText = secondsightify(String(customStatus));
+							if(DiscordModules.UserStatusStore.getActivities(args[0]).length > 0){
+								let activities = DiscordModules.UserStatusStore.getActivities(args[0]);
+								if(activities[0].name != "Custom Status") return;
+								let customStatus = activities[0].state;
+								if(customStatus == undefined) return;
+								revealedTextLocal = secondsightify(String(customStatus));
+								return revealedTextLocal;
+							}
 						}
+						let revealedText = getRevealedText();
 						if(revealedText == undefined) return;
 						if(revealedText == "") return;
 						


### PR DESCRIPTION
+Changed how Fake Avatar Decorations work so that you can have the 3y3-encoded data in **both your bio *and* your custom status**. If you have the 3y3 data in both, people will see your avatar decoration without clicking your profile (if you are online) and with having to click your profile (if you are offline).
+Updated readme