### PR TITLE
Emoji size selection dropdown + fixes

### DIFF
--- a/YABDP4Nitro.plugin.js
+++ b/YABDP4Nitro.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name YABDP4Nitro
  * @author Riolubruh
- * @version 5.0.9
+ * @version 5.1.0
  * @source https://github.com/riolubruh/YABDP4Nitro
  * @updateUrl https://raw.githubusercontent.com/riolubruh/YABDP4Nitro/main/YABDP4Nitro.plugin.js
  */

--- a/YABDP4Nitro.plugin.js
+++ b/YABDP4Nitro.plugin.js
@@ -178,18 +178,24 @@ module.exports = (() => {
 						]),
 						new Settings.SettingGroup("Emojis").append(
 							new Settings.Switch("Nitro Emotes Bypass", "Enable or disable using the emoji bypass.", this.settings.emojiBypass, value => this.settings.emojiBypass = value),
-							new Settings.Textbox("Size", "The size of the emoji in pixels. Valid values: 16, 32, 48, 64, 80, 96, 112, 128, or powers of 2.", this.settings.emojiSize,
+							new Settings.Dropdown("Size", "The size of the emoji in pixels.", this.settings.emojiSize, [
+									{label: "32px (Default small/inline)", value: 32},
+									{label: "48px (Recommended, default large)", value: 48},
+									{label: "16px", value: 16},
+									{label: "24px", value: 24},
+									{label: "40px", value: 40},
+									{label: "56px", value: 56},
+									{label: "64px", value: 64},
+									{label: "80px", value: 80},
+									{label: "96px", value: 96},
+									{label: "128px (Max emoji size)", value: 128}
+								], 
 								value => {
-									value = parseInt(value);
 									if (isNaN(value)) {
-										value = 64;
-									} else if (value > 128) {
-										value = Math.pow(2, Math.round(Math.log(value) / Math.log(2))); 
-									} else if (![16, 32, 48, 64, 80, 96, 112, 128].includes(value)) {
-										value = Math.min.apply(Math, [16, 32, 48, 64, 80, 96, 112, 128].filter(function(x) { return x > value }));
+										value = 48;
 									}
-									this.settings.emojiSize = value;
-								}
+									this.settings.emojiSize = value
+								}, {searchable: true}
 							),
 							new Settings.Switch("Ghost Mode", "Abuses ghost message bug to hide the emoji url.", this.settings.ghostMode, value => this.settings.ghostMode = value),
 							new Settings.Switch("Don't Use Emote Bypass if Emote is Unlocked", "Disable to use emoji bypass even if bypass is not required for that emoji.", this.settings.emojiBypassForValidEmoji, value => this.settings.emojiBypassForValidEmoji = value),

--- a/YABDP4Nitro.plugin.js
+++ b/YABDP4Nitro.plugin.js
@@ -188,7 +188,8 @@ module.exports = (() => {
 									{label: "64px", value: 64},
 									{label: "80px", value: 80},
 									{label: "96px", value: 96},
-									{label: "128px (Max emoji size)", value: 128}
+									{label: "128px (Max emoji size)", value: 128},
+									{label: "256px (Max GIF emoji size)", value: 256}
 								], 
 								value => {
 									if (isNaN(value)) {


### PR DESCRIPTION
**Replaces #176**

Changed the emoji size selection from textbox to a dropdown. Trimmed anything below Discord's max emoji size (128px) and added a few more options in the low range.

![image](https://i.gyazo.com/8354a0a34f83095c0396cfe0139fb696.gif)

### Reason
The old textbox code I wrote was janky and a few values were invalid. Additionally, while the Discord CDN will return an emoji image for requested sizes above 128px, all emojis are reduced to a maximum of 128x128 when uploaded to Discord (I confirmed this by uploading a very compressed 1024px image; `?size=1024` still returned a 128x128px image in both Discord and directly in the browser). This made it reasonable to simply use a dropdown, as there are no longer dozens of potential values to choose from.

**EDIT:** Looks like GIFs can go up to 256px, so I added that as an option as well.