### PR TITLE
5.6.10 -- Replace old deprecated functions

### DIFF
--- a/YABDP4Nitro.plugin.js
+++ b/YABDP4Nitro.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name YABDP4Nitro
  * @author Riolubruh
- * @version 5.6.9
+ * @version 5.6.10
  * @invite EFmGEWAUns
  * @source https://github.com/riolubruh/YABDP4Nitro
  * @donate https://github.com/riolubruh/YABDP4Nitro?tab=readme-ov-file#donate
@@ -60,7 +60,7 @@ const canUserUseMod = Webpack.getMangled(".getFeatureValue(", {
     canUserUse: Webpack.Filters.byStrings("getFeatureValue")
 });
 const AvatarDefaults = Webpack.getByKeys("getEmojiURL");
-const LadderModule = Webpack.getModule(Webpack.Filters.byProps("calculateLadder"), { searchExports: true });
+const LadderModule = Webpack.getModule(Webpack.Filters.byKeys("calculateLadder"), { searchExports: true });
 const FetchCollectibleCategories = Webpack.getByStrings('{type:"COLLECTIBLES_CATEGORIES_FETCH"', { searchExports: true });
 let ffmpeg = undefined;
 const MP4Box = Webpack.getByKeys("MP4BoxStream");
@@ -81,7 +81,7 @@ const stickerSendabilityModule = Webpack.getMangled("SENDABLE_WITH_BOOSTED_GUILD
     getStickerSendability: Webpack.Filters.byStrings("canUseCustomStickersEverywhere"),
     isSendableSticker: Webpack.Filters.byStrings(")=>0===")
 });
-const clientThemesModule = Webpack.getModule(Webpack.Filters.byProps("isPreview"));
+const clientThemesModule = Webpack.getModule(Webpack.Filters.byKeys("isPreview"));
 const streamSettingsMod = Webpack.getByPrototypeKeys("getCodecOptions").prototype;
 const themesModule = Webpack.getMangled("changes:{appearance:{settings:{clientThemeSettings:{", {
     saveClientTheme: Webpack.Filters.byStrings("changes:{appearance:{settings:{clientThemeSettings:{")
@@ -163,17 +163,17 @@ const config = {
             "discord_id": "359063827091816448",
             "github_username": "riolubruh"
         }],
-        "version": "5.6.9",
+        "version": "5.6.10",
         "description": "Unlock all screensharing modes, and use cross-server & GIF emotes!",
         "github": "https://github.com/riolubruh/YABDP4Nitro",
         "github_raw": "https://raw.githubusercontent.com/riolubruh/YABDP4Nitro/main/YABDP4Nitro.plugin.js"
     },
     changelog: [
         {
-            title: "5.6.9",
+            title: "5.6.10",
             items: [
-                "Make Clips Bypass more reliable by checking if ffmpeg is loaded upon adding a file and triggering it to load if it isn't.",
-                "Fixed the screen share getting put into an infinite buffering screen when turning on or off the camera."
+                "Replace deprecated function BdApi.Filters.byProps with BdApi.Filters.byKeys since it is about to be removed.",
+                "Replace deprecated function BdApi.getData with BdApi.Data.load since it is about to be removed."
             ]
         }
     ],
@@ -1314,7 +1314,7 @@ module.exports = class YABDP4Nitro {
         if(settings.killProfileEffects) return; //profileFX is mutually exclusive with killProfileEffects (obviously)
 
         //wait for profile effects module
-        await Webpack.waitForModule(Webpack.Filters.byProps("profileEffects", "tryItOutId"));
+        await Webpack.waitForModule(Webpack.Filters.byKeys("profileEffects", "tryItOutId"));
 
         if (this.profileEffects == undefined) this.profileEffects = Webpack.getStore("ProfileEffectStore").profileEffects;
 
@@ -1605,7 +1605,7 @@ module.exports = class YABDP4Nitro {
             );
 
 
-            let listOfDecorationIds = Object.keys(BdApi.getData(this.meta.name, "settings").avatarDecorations);
+            let listOfDecorationIds = Object.keys(Data.load(this.meta.name, "settings").avatarDecorations);
             let avatarDecorationChildren = [];
 
             //for each avatar decoration
@@ -2286,7 +2286,7 @@ module.exports = class YABDP4Nitro {
 
     //#region Streaming Unlock
     unlockAndCustomizeStreamButtons(){ //Unlock stream buttons, apply custom resolution and fps, and apply stream quality bypasses
-        const settings = BdApi.getData("YABDP4Nitro", "settings"); //just in case we can't access "this";
+        const settings = Data.load("YABDP4Nitro", "settings"); //just in case we can't access "this";
 
         //If custom resolution tick is disabled or custom resolution is set to 0, set it to 1440
         let resolutionToSet = parseInt(settings.CustomResolution);
@@ -2495,7 +2495,7 @@ module.exports = class YABDP4Nitro {
     async encodeProfileColors(){
 
         //wait for theme color picker module to be loaded
-        await Webpack.waitForModule(Webpack.Filters.byProps("getTryItOutThemeColors"));
+        await Webpack.waitForModule(Webpack.Filters.byKeys("getTryItOutThemeColors"));
 
         //wait for color picker renderer module to be loaded
         await Webpack.waitForModule(Webpack.Filters.byStrings("__invalid_profileThemesSection"));


### PR DESCRIPTION
+Replace deprecated function BdApi.Filters.byProps with BdApi.Filters.byKeys since it is about to be removed.
+Replace deprecated function BdApi.getData with BdApi.Data.load since it is about to be removed.